### PR TITLE
Fix broken link to average_mean.py a

### DIFF
--- a/Basic Math/Average_Mean.md
+++ b/Basic Math/Average_Mean.md
@@ -59,7 +59,7 @@ Return the value of 22.<u>857142</u> or `23`.
 
 ## Implementation
 
--   [Python](https://github.com/TheAlgorithms/Python/blob/master/maths/average.py)
+-   [Python](https://github.com/TheAlgorithms/Python/blob/master/maths/average_mean.py)
 
 ## Video URL
 


### PR DESCRIPTION
Rename average.py to average_mean.py in commit: TheAlgorithms/Python#939