### PR TITLE
Fixed some broken links on Bellman-Ford.md (Brazilian translation)

### DIFF
--- a/pt-br/Estruturas de Dados/Graph/Bellman-Ford.md
+++ b/pt-br/Estruturas de Dados/Graph/Bellman-Ford.md
@@ -89,9 +89,9 @@ E 1 A-> B-> E = -1 + 2
 #### Links de implementação de código
 
 - [Java](https://github.com/TheAlgorithms/Java/blob/master/DataStructures/Graphs/BellmanFord.java)
-- [C++](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/Dynamic%20Programming/Bellman-Ford.cpp)
-- [Python](https://github.com/TheAlgorithms/Python/blob/master/data_structures/graph/bellman_ford.py)
-- [C](https://github.com/TheAlgorithms/C/blob/master/data_structures/graphs/Bellman-Ford.c)
+- [C++](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/dynamic_programming/bellman_ford.cpp)
+- [Python](https://github.com/TheAlgorithms/Python/blob/master/graphs/bellman_ford.py)
+- [C](https://github.com/TheAlgorithms/C/blob/master/data_structures/graphs/bellman_ford.c)
 
 #### Explicação em vídeo
 


### PR DESCRIPTION
`pt-br/Estruturas de Dados/Graph/Bellman-Ford.md` had broken links, so I replaced them with the links on the respective english file.
