### PR TITLE
Updated broken links of bubbleSort

### DIFF
--- a/en/Sorting Algorithms/Bubble Sort.md
+++ b/en/Sorting Algorithms/Bubble Sort.md
@@ -81,7 +81,7 @@ Since there are no swaps in above steps, it means the array is sorted and we can
 
 #### Code Implementation Links
 
-- [Java](https://github.com/TheAlgorithms/Java/blob/master/Sorts/BubbleSort.java)
+- [Java](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/sorts/BubbleSort.java)
 - [C++](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/sorting/bubble_sort.cpp)
 - [Python](https://github.com/TheAlgorithms/Python/blob/master/sorts/bubble_sort.py)
 - [C-Sharp](https://github.com/TheAlgorithms/C-Sharp/blob/master/Algorithms/Sorters/Comparison/BubbleSorter.cs)

--- a/es/Algoritmos de Ordenamiento/Ordenamiento Burbuja.md
+++ b/es/Algoritmos de Ordenamiento/Ordenamiento Burbuja.md
@@ -81,7 +81,7 @@ Como no hay intercambios en los pasos de arriba, el arreglo ya se ha ordenado y 
 
 #### Enlaces a implementaciones de código
 
-- [Java](https://github.com/TheAlgorithms/Java/blob/master/Sorts/BubbleSort.java)
+- [Java](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/sorts/BubbleSort.java)
 - [C++](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/Sorting/Bubble%20Sort.cpp)
 - [Python](https://github.com/TheAlgorithms/Python/blob/master/sorts/bubble_sort.py)
 - [C-Sharp](https://github.com/TheAlgorithms/C-Sharp/blob/master/sorts/bubble_sort.cs)


### PR DESCRIPTION
Fixes Issue:  #154

Updated Links of `en\Sorting Algorithms\Bubble Sort.md` and `es\Algoritmos de Ordenamiento\Ordenamiento Burbuja.md`
They are redirecting to the correct locations.