### PR TITLE
docs: fix broken link to the license file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Contributions must be all your own work; plagiarism is not allowed.
 By submitting a pull request, you agree to license your contribution
-under the [license of this repository](https://github.com/TheAlgorithms/Algorithms-Explanation/blob/master/LICENSE.txt).
+under the [license of this repository](./LICENSE.txt).
 
 ## Translations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Contributions must be all your own work; plagiarism is not allowed.
 By submitting a pull request, you agree to license your contribution
-under the [license of this repository](https://github.com/TheAlgorithms/Algorithms-Explanation/blob/master/LICENSE.md).
+under the [license of this repository](https://github.com/TheAlgorithms/Algorithms-Explanation/blob/master/LICENSE.txt).
 
 ## Translations
 


### PR DESCRIPTION
### Description

<!-- Provide a description of the introduced changes in this pull request. -->
<!-- If the pull request closes an issue, please update the issue ID below. -->

Related to #154.

Fixes the link to the license. Please notice that I decided to leave the _absolute path_. I am not sure what it the legal point of view, but it somehow makes sense that each fork and branch is under the **same** license.

### Checklist

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing checks pass.
- [x] No plagiarized, duplicated, or repetitive documentation that has been directly copied from another source.
- [x] If it's a new explanation, it contains solid, understandable, and accessible information.
- [x] I have read the whole [contributing guidelines](https://github.com/TheAlgorithms/Algorithms-Explanation/blob/master/CONTRIBUTING.md) and agree to the [Code of Conduct](https://github.com/TheAlgorithms/.github/blob/master/CODE_OF_CONDUCT.md).

### Screenshots (if any)

<!--

If any, add screenshots to help explain your changes.
Remove these comments to highlight the screenshots in the PR.

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

-->

### Note to reviewers

<!-- Please add a one-line description for developers or pull request viewers, if any. -->
