### PR TITLE
chore: fail `url_check` when broken links are found

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -24,5 +24,5 @@ jobs:
           args: >
             --no-progress
             *
-          fail: false
+          fail: true
 ...


### PR DESCRIPTION
### Description


Related to #154.

Having
- #237
- #238
- #239
- #240

merged will allow to make the `url_check` truly detect broken links. This PR reverts cd0f44170e08819707abca0b43329cdfb3296ea8 in #231.

Clearly, please _rebase_ before merging.

### Checklist

- [x] A description of the changes in this PR is mentioned above.
- [x] All the new and existing checks pass.
- [x] No plagiarized, duplicated, or repetitive documentation that has been directly copied from another source.
- [x] If it's a new explanation, it contains solid, understandable, and accessible information.
- [x] I have read the whole [contributing guidelines](https://github.com/TheAlgorithms/Algorithms-Explanation/blob/master/CONTRIBUTING.md) and agree to the [Code of Conduct](https://github.com/TheAlgorithms/.github/blob/master/CODE_OF_CONDUCT.md).
