### PR TITLE
Fix misleading phrase "arrays of lists" in stack implementation description

### DIFF
--- a/en/Data Structures/Stacks/stack.md
+++ b/en/Data Structures/Stacks/stack.md
@@ -3,7 +3,7 @@
 A stack is a basic linear data structure that follows an order in which objects are accessed. The order is called LIFO(Last In First Out)or FILO(First in Last Out).
 A perfect example of stacks would be plates in a canteen, a pile of books, or a box of Pringles,etc.
 Stacks are used to implement parsers and evaluation expressions and backtracking algorithms. basic operations are pushing an element into the stack and popping the element out of the stack.
-We can make use of linked lists or arrays of lists. The stack contains only one pointer
+Stacks can be implemented using either arrays or linked lists. The stack contains only one pointer
 "top pointer" which points to the topmost elements of the stack. Insertion and deletion  only occurs at one end of the stack.
 
 # Standard Stack Operations 


### PR DESCRIPTION
This PR fixes a minor but potentially confusing phrase in the explanation of stack implementations. This small change is intended to provide clarity to readers.

The original sentence:

>"We can make use of linked lists or **arrays of lists**."

has been updated to:

>"Stacks can be implemented using either arrays or linked lists."

### Reason for Change
The phrase "**arrays of lists**" is misleading when discussing stack implementations. It may suggest a 2D structure or a collection of lists, which is not relevant for implementing a basic stack. Stacks are most commonly implemented using either:

1. Arrays (for static or dynamic sizing)
2. Linked lists (for dynamic memory usage)